### PR TITLE
Fix XAML binding errors

### DIFF
--- a/Amuse.UI/App.xaml
+++ b/Amuse.UI/App.xaml
@@ -30,11 +30,14 @@
 
         <system:Boolean x:Key="True">True</system:Boolean>
         <system:Boolean x:Key="False">False</system:Boolean>
+
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+
         <converters:InverseBooleanToVisibilityConverter x:Key="InverseBooleanToVisibilityConverter" />
         <converters:InverseBoolConverter x:Key="InverseBoolConverter" />
         <converters:BooleanToHiddenConverter x:Key="BooleanToHiddenConverter" />
         <converters:InverseBooleanToHiddenConverter x:Key="InverseBooleanToHiddenConverter" />
+        <converters:ColorToBrushConverter x:Key="ColorToBrushConverter" />
         <converters:NullVisibilityConverter x:Key="NullVisibilityConverter" />
         <converters:InverseNullVisibilityConverter x:Key="InverseNullVisibilityConverter" />
         <converters:DiffuserVisibilityConverter x:Key="DiffuserVisibilityConverter" />
@@ -42,6 +45,7 @@
         <converters:ComboBoxAllItemConverter x:Key="ComboBoxAllItemConverter" />
         <converters:EnumDescriptionConverter x:Key="EnumDescriptionConverter" />
         <converters:FullPathToFileNameConverter x:Key="FullPathToFileNameConverter" />
+        <converters:StringToUriConverter x:Key="StringToUriConverter" />
 
         <ObjectDataProvider x:Key="ListSortDirection" MethodName="GetValues" ObjectType="{x:Type system:Enum}">
             <ObjectDataProvider.MethodParameters>

--- a/Amuse.UI/Converters/ColorToBrushConverter.cs
+++ b/Amuse.UI/Converters/ColorToBrushConverter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace Amuse.UI.Converters
+{
+    [ValueConversion(typeof(Color), typeof(SolidColorBrush))]
+    public class ColorToBrushConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is Color colorValue)
+            {
+                return new SolidColorBrush(colorValue);
+            }
+            throw new NotImplementedException();
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Amuse.UI/Converters/ComboBoxAllItemConverter.cs
+++ b/Amuse.UI/Converters/ComboBoxAllItemConverter.cs
@@ -7,15 +7,45 @@ using System.Windows.Data;
 
 namespace Amuse.UI.Converters
 {
+    // Class that represents the "All" Item in the combo box
+    // It has properties for the bindings that are read by the XAML
+    // in order to prevent binding link errors
     public class ComboBoxAllItemConverter : IValueConverter
     {
+        private class AllComboxBoxItem
+        {
+            public string Template
+            {
+                get
+                {
+                    return "All";
+                }
+            }
+
+            public string Name
+            {
+                get
+                {
+                    return "All";
+                }
+            }
+
+            public bool IsUserTemplate
+            {
+                get
+                {
+                    return false;
+                }
+            }
+        }
+
+        private static readonly AllComboxBoxItem _allComboxBoxItem = new AllComboxBoxItem();
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            IEnumerable container = value as IEnumerable;
-            if (container != null)
+            if (value is IEnumerable container)
             {
                 IEnumerable<object> genericContainer = container.OfType<object>();
-                IEnumerable<object> emptyItem = new object[] { "All" };
+                IEnumerable<object> emptyItem = new object[] { _allComboxBoxItem };
                 return emptyItem.Concat(genericContainer);
             }
 
@@ -24,7 +54,11 @@ namespace Amuse.UI.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return value is string str && str == "All" ? null : value;
+            if (value is string str && str.Equals(_allComboxBoxItem.Template))
+            {
+                return null;
+            }
+            return value;
         }
     }
 }

--- a/Amuse.UI/Converters/StringToUriConverter.cs
+++ b/Amuse.UI/Converters/StringToUriConverter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Amuse.UI.Converters
+{
+    [ValueConversion(typeof(string), typeof(Uri))]
+    public class StringToUriConverter : IValueConverter
+    {
+        private readonly Uri nullUri = new Uri("about:blank");
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            string stringToConvert = (string)value;
+            if (stringToConvert != null)
+            {
+                return new Uri(stringToConvert);
+            }
+            return nullUri;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            Uri uriToConvertBack = (Uri)value;
+            if (uriToConvertBack != null && !uriToConvertBack.Equals(nullUri))
+            {
+                return uriToConvertBack.OriginalString;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Amuse.UI/Models/ModelTemplateViewModel.cs
+++ b/Amuse.UI/Models/ModelTemplateViewModel.cs
@@ -1,6 +1,8 @@
 ﻿using OnnxStack.Core;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Data.SqlTypes;
 using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
 using System.Threading;

--- a/Amuse.UI/Services/UpscaleService.cs
+++ b/Amuse.UI/Services/UpscaleService.cs
@@ -13,7 +13,7 @@ namespace Amuse.UI.Services
 {
     public class UpscaleService : IUpscaleService
     {
-        private readonly ILogger<StableDiffusionService> _logger;
+        private readonly ILogger<StableDiffusionService> _logger = null;
         private readonly Dictionary<IOnnxModel, ImageUpscalePipeline> _pipelines;
 
         /// <summary>

--- a/Amuse.UI/UserControls/ImageInputControl.xaml
+++ b/Amuse.UI/UserControls/ImageInputControl.xaml
@@ -4,10 +4,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
-             xmlns:local="clr-namespace:Amuse.UI.UserControls"
              xmlns:userControls="clr-namespace:Amuse.UI.UserControls"
              xmlns:behaviors="clr-namespace:Amuse.UI.Behaviors"
-             xmlns:models="clr-namespace:Amuse.UI.Models"
              mc:Ignorable="d" 
              d:DesignWidth="500" Name="UI" Focusable="True"  PreviewKeyDown="OnPreviewKeyDown" MouseEnter="OnMouseEnter" AllowDrop="True" PreviewDrop="OnPreviewDrop">
     <Border DataContext="{Binding ElementName=UI}" BorderBrush="{StaticResource ControlBrightDefaultBorderBrush}" BorderThickness="2" >

--- a/Amuse.UI/UserControls/ImageResultControl.xaml
+++ b/Amuse.UI/UserControls/ImageResultControl.xaml
@@ -3,10 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:Amuse.UI.UserControls"
              xmlns:userControls="clr-namespace:Amuse.UI.UserControls"
              xmlns:behaviors="clr-namespace:Amuse.UI.Behaviors"
-             xmlns:models="clr-namespace:Amuse.UI.Models"
              xmlns:views="clr-namespace:Amuse.UI.Views"
              mc:Ignorable="d" 
              d:DesignWidth="500" Name="UI" Focusable="True" PreviewKeyDown="OnPreviewKeyDown" MouseEnter="OnMouseEnter">

--- a/Amuse.UI/UserControls/PaintInputControl.xaml
+++ b/Amuse.UI/UserControls/PaintInputControl.xaml
@@ -8,7 +8,7 @@
              xmlns:local="clr-namespace:Amuse.UI.UserControls"
              xmlns:userControls="clr-namespace:Amuse.UI.UserControls"
              xmlns:behaviors="clr-namespace:Amuse.UI.Behaviors"
-             xmlns:models="clr-namespace:Amuse.UI.Models"
+             xmlns:converters="clr-namespace:Amuse.UI.Converters"
              mc:Ignorable="d" 
              d:DesignWidth="500" Name="UI" Focusable="True"  PreviewKeyDown="OnPreviewKeyDown" MouseEnter="OnMouseEnter" AllowDrop="True" PreviewDrop="OnPreviewDrop" PreviewMouseWheel="OnMouseWheel">
     <Border DataContext="{Binding ElementName=UI}" BorderBrush="{StaticResource ControlBrightDefaultBorderBrush}" BorderThickness="2" >
@@ -21,12 +21,16 @@
 
                         <!--Recent Colors-->
                         <ListView ItemsSource="{Binding RecentColors, ElementName=ColorPickerControl}" SelectedValue="{Binding SelectedColor}" SelectedValuePath="Color" Background="Transparent" BorderBrush="Transparent">
+                            <ListView.Resources>
+                                <converters:ColorToBrushConverter x:Key="ColorToBrushConverter" />
+                            </ListView.Resources>
                             <ListView.ItemContainerStyle>
                                 <Style TargetType="{x:Type ListViewItem}">
-                                    <Setter Property="Background">
-                                        <Setter.Value>
-                                            <SolidColorBrush Color="{Binding Color}" />
-                                        </Setter.Value>
+                                    <Setter Property="Background" Value="{Binding Color, Converter={StaticResource ColorToBrushConverter}}" >
+                                        <!--<Setter.Value>
+                                                --><!--<Binding  brush Path="Color" UpdateSourceTrigger="PropertyChanged" /> --><!--
+                                                <SolidColorBrush Color="{Binding Color, }" />
+                                        </Setter.Value>-->
                                     </Setter>
                                     <Setter Property="Template">
                                         <Setter.Value>

--- a/Amuse.UI/UserControls/PromptControl.xaml
+++ b/Amuse.UI/UserControls/PromptControl.xaml
@@ -3,7 +3,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:local="clr-namespace:Amuse.UI.UserControls"
              xmlns:behaviors="clr-namespace:Amuse.UI.Behaviors"
              mc:Ignorable="d" 
              d:DesignWidth="500" Name="UI">

--- a/Amuse.UI/UserControls/SchedulerControl.xaml
+++ b/Amuse.UI/UserControls/SchedulerControl.xaml
@@ -4,7 +4,6 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
-             xmlns:local="clr-namespace:Amuse.UI.Views"
              xmlns:behaviors="clr-namespace:Amuse.UI.Behaviors"
              xmlns:userControls="clr-namespace:Amuse.UI.UserControls"
              mc:Ignorable="d" 

--- a/Amuse.UI/UserControls/VideoInputControl.xaml
+++ b/Amuse.UI/UserControls/VideoInputControl.xaml
@@ -3,13 +3,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
-             xmlns:local="clr-namespace:Amuse.UI.UserControls"
              xmlns:userControls="clr-namespace:Amuse.UI.UserControls"
-             xmlns:behaviors="clr-namespace:Amuse.UI.Behaviors"
-             xmlns:models="clr-namespace:Amuse.UI.Models"
              mc:Ignorable="d" 
-              Name="UI" Focusable="True" >
+             Name="UI" Focusable="True" >
 
     <Border DataContext="{Binding ElementName=UI}" BorderBrush="{StaticResource ControlBrightDefaultBorderBrush}"  BorderThickness="2" >
         <DockPanel Margin="2" >

--- a/Amuse.UI/UserControls/VideoResultControl.xaml
+++ b/Amuse.UI/UserControls/VideoResultControl.xaml
@@ -3,11 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-             xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
-             xmlns:local="clr-namespace:Amuse.UI.UserControls"
              xmlns:userControls="clr-namespace:Amuse.UI.UserControls"
              xmlns:behaviors="clr-namespace:Amuse.UI.Behaviors"
-             xmlns:models="clr-namespace:Amuse.UI.Models"
              xmlns:views="clr-namespace:Amuse.UI.Views"
              mc:Ignorable="d" 
               Name="UI" Focusable="True" >

--- a/Amuse.UI/Views/ModelSettingsView.xaml
+++ b/Amuse.UI/Views/ModelSettingsView.xaml
@@ -173,7 +173,7 @@
                                                 <StackPanel Visibility="{Binding SelectedModelTemplate.Website, Converter={StaticResource NullVisibilityConverter}}" Margin="0,2,0,0">
                                                     <TextBlock Grid.Column="0" Grid.Row="2" Text="Website" FontStyle="Italic" FontSize="10" Opacity=".7"/>
                                                     <TextBlock Margin="0,-3,0,0">
-                                                         <Hyperlink NavigateUri="{Binding SelectedModelTemplate.Website}" Command="{Binding HyperLinkNavigateCommand}" CommandParameter="{Binding SelectedModelTemplate.Website}" Foreground="LightBlue" >
+                                                         <Hyperlink NavigateUri="{Binding SelectedModelTemplate.Website, Converter={StaticResource StringToUriConverter}}" Command="{Binding HyperLinkNavigateCommand}" CommandParameter="{Binding SelectedModelTemplate.Website}" Foreground="LightBlue" >
                                                             <Run Text="{Binding SelectedModelTemplate.Website}" />
                                                          </Hyperlink>
                                                     </TextBlock>
@@ -182,7 +182,7 @@
                                                 <StackPanel Visibility="{Binding SelectedModelTemplate.Repository, Converter={StaticResource NullVisibilityConverter}}" Margin="0,2,0,0">
                                                     <TextBlock Grid.Column="0" Grid.Row="2" Text="Repository" FontStyle="Italic" FontSize="10" Opacity=".7"/>
                                                     <TextBlock Margin="0,-3,0,0" TextTrimming="CharacterEllipsis">
-                                                      <Hyperlink NavigateUri="{Binding SelectedModelTemplate.Repository}" Command="{Binding HyperLinkNavigateCommand}" CommandParameter="{Binding SelectedModelTemplate.Repository}" Foreground="LightBlue" >
+                                                      <Hyperlink NavigateUri="{Binding SelectedModelTemplate.Repository, Converter={StaticResource StringToUriConverter}}" Command="{Binding HyperLinkNavigateCommand}" CommandParameter="{Binding SelectedModelTemplate.Repository}" Foreground="LightBlue" >
                                                          <Run Text="{Binding SelectedModelTemplate.Repository}" />
                                                       </Hyperlink>
                                                     </TextBlock>

--- a/Amuse.UI/Views/UpscaleView.xaml.cs
+++ b/Amuse.UI/Views/UpscaleView.xaml.cs
@@ -2,7 +2,9 @@
 using Amuse.UI.Models;
 using Amuse.UI.Services;
 using Microsoft.Extensions.Logging;
+using Models;
 using OnnxStack.Core.Image;
+using OnnxStack.StableDiffusion.Config;
 using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -33,10 +35,11 @@ namespace Amuse.UI.Views
         private bool _isControlsEnabled;
         private UpscaleResult _resultImage;
         private UpscaleModelSetViewModel _selectedModel;
-        private CancellationTokenSource _cancelationTokenSource;
+        private CancellationTokenSource _cancelationTokenSource = null;
         private BitmapSource _inputImage;
         private string _imageFile;
         private UpscaleInfoModel _upscaleInfo;
+        private BatchOptionsModel _batchOptions;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UpscaleView"/> class.
@@ -100,15 +103,17 @@ namespace Amuse.UI.Views
             set { _imageFile = value; NotifyPropertyChanged(); LoadImage(); }
         }
 
-
-
         public UpscaleInfoModel UpscaleInfo
         {
             get { return _upscaleInfo; }
             set { _upscaleInfo = value; NotifyPropertyChanged(); }
         }
 
-
+        public BatchOptionsModel BatchOptions
+        {
+            get { return _batchOptions; }
+            set { _batchOptions = value; NotifyPropertyChanged(); }
+        }
 
         public int ProgressValue
         {


### PR DESCRIPTION
I spent a few minutes going over the binding errors and fixed them.
Now there is no XAML binding errors anymore.

I also cleaned up a few unnecessary `using` in some files and a few warnings about a few members that are not initialized by explicitly setting them to null where they are declared.